### PR TITLE
component: add option to disable shared libs

### DIFF
--- a/build-ecp-veloc-component/action.yml
+++ b/build-ecp-veloc-component/action.yml
@@ -9,10 +9,14 @@ inputs:
     description: 'MPI status'
     required: false
     default: par
-  static:
-    description: 'static library build'
+  shared:
+    description: 'enable build of shared library: build-shared, build-static'
     required: false
-    default: false
+    default: build-shared
+  static:
+    description: 'link binaries to which lib: link-shared, link-static'
+    required: false
+    default: link-shared
   ref:
     description: 'SHA or tag to checkout'
     required: false
@@ -36,6 +40,6 @@ runs:
         cd ${{ inputs.component }}
         mkdir build
         cd build
-        cmake ../ -DMPI=${{ inputs.mpi == 'par' }} -D$(echo ${{ inputs.component }} | tr 'a-z' 'A-Z')_LINK_STATIC=${{ inputs.static }} -DCMAKE_INSTALL_PREFIX=../../install
+        cmake ../ -DMPI=${{ inputs.mpi == 'par' }} -DBUILD_SHARED_LIBS=${{ inputs.shared == 'build-shared' }} -D$(echo ${{ inputs.component }} | tr 'a-z' 'A-Z')_LINK_STATIC=${{ inputs.static == 'link-static' }} -DCMAKE_INSTALL_PREFIX=../../install
         make
         make install

--- a/cmake-build-only/action.yml
+++ b/cmake-build-only/action.yml
@@ -9,6 +9,14 @@ inputs:
     description: 'CMake Build Type'
     required: false
     default: Release
+  shared:
+    description: 'enable build of shared library: build-shared, build-static'
+    required: false
+    default: build-shared
+  static:
+    description: 'link binaries to which lib: link-shared, link-static'
+    required: false
+    default: link-shared
   cmake_line:
     description: 'Additional CMake build options'
     required: false
@@ -24,5 +32,5 @@ runs:
         mkdir build
         mkdir -p install
         cd build
-        cmake ../${{ inputs.component }} -DCMAKE_BUILD_TYPE=${{ inputs.target }} -DCMAKE_INSTALL_PREFIX=../install ${{ inputs.cmake_line }}
+        cmake ../${{ inputs.component }} -DCMAKE_BUILD_TYPE=${{ inputs.target }} -DBUILD_SHARED_LIBS=${{ inputs.shared == 'build-shared' }} -D$(echo ${{ inputs.component }} | tr 'a-z' 'A-Z')_LINK_STATIC=${{ inputs.static == 'link-static' }} -DCMAKE_INSTALL_PREFIX=../install ${{ inputs.cmake_line }}
         make


### PR DESCRIPTION
Some code teams prefer to build everything with ``-DBUILD_SHARED_LIBS=OFF``.  This adds a configuration to toggle ``-DBUILD_SHARED_LIBS`` when building a component including its dependencies.  A new ``shared`` option is added to the configuration, which can be set to ``true`` or ``false``.